### PR TITLE
Bugfixes if config != LED+BT, code cleanup

### DIFF
--- a/Code/platformio.ini
+++ b/Code/platformio.ini
@@ -11,48 +11,24 @@
 [platformio]
 env_default = uno
 
+[common]
+; 887 is LiquidCrystal from Adafruit
+; Do not add it to lib_deps, it causes trouble.
+lib_deps =
+    Bounce2@2.1
+    LedControl@1.0.6
+
 [env:mega2560]
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
 build_flags = '-DMEGA2560'
+lib_deps = ${common.lib_deps}
 
 [env:uno]
 platform = atmelavr
 board = uno
-//board = nanoatmega328
+;board = nanoatmega328
 framework = arduino
 build_flags = '-DUNO'
-
-lib_deps =
-     # Using library Id
-     914
-
-     # Using library Name
-     LedControl
-
-     # Depend on specific version
-     LedControl@1.0.6
-
-     # Semantic Versioning Rules
-
-     LedControl@^1.0.6
-
-     LedControl@~1.0.6
-
-     LedControl@>=1.0.6
-
-     lib_deps =
-          # Using library Id
-          1106
-
-          # Using library Name
-          Bounce2
-
-          # Depend on specific version
-          Bounce2@2.1
-
-          # Semantic Versioning Rules
-          Bounce2@^2.1
-          Bounce2@~2.1
-          Bounce2@>=2.1
+lib_deps = ${common.lib_deps}

--- a/Code/src/UWR_Hupe.ino
+++ b/Code/src/UWR_Hupe.ino
@@ -1,19 +1,8 @@
-//#include "LedControl.h" //  need the library
-#include <SoftwareSerial.h>// import the serial library
-#include "constants.h"
 #include <Bounce2.h>
 
 #include "config.h"
 #include "bluetooth.h"
 #include "display.h"
-
-//SoftwareSerial Bluetooth(9, 8); // RX, TX
-//LedControl lc = LedControl(12, 11, 10, 1); //
-// pin 12 is connected to DOUT
-// pin 11 is connected to the CLK
-// pin 10 is connected to LOAD
-
-
 
 
 unsigned long Start = 0;
@@ -87,18 +76,10 @@ unsigned long StartTimerHalbzeitPause=0;
 char BluetoothBuffer[4];
 char BluetoothTrennzeichen[]=";";
 char BluetoothString[33];
-
 #endif
 
 
-
-//Drücker abfragen
-//bool DrueckerSpielleiter=1;
-//bool DrueckerUW1=1;
-//bool DrueckerUW2=1;
-//unsigned long TimerDrueckerSpielleiter=0;
-//unsigned long TimerDrueckerUW1=0;
-//unsigned long TimerDrueckerUW2=0;
+// Drücker
 Bounce DrueckerSpielleiter = Bounce();
 Bounce DrueckerUW1 = Bounce();
 Bounce DrueckerUW2 = Bounce();
@@ -106,6 +87,14 @@ Bounce DrueckerUW2 = Bounce();
 
 void setup()
 {
+        #if OUTPUT_SERIAL
+        Serial.begin(9600);
+        while (!Serial) {
+          ; // wait for serial port to connect. Needed for native USB port only
+        }
+        Serial.write("setup() starting\n");
+        #endif
+
         #if OUTPUT_LED
         lc.shutdown(0, false); // turn off power saving, enables display
         lc.setIntensity(0, 8); // sets brightness (0~15 possible values)
@@ -127,11 +116,11 @@ void setup()
 
         #if OUTPUT_BLUETOOTH
         Bluetooth.begin(9600);
+        #endif
 
-        //Serial.begin(9600);
-        pinMode(PinDrueckerSpielleiter, INPUT);     // set pin to input
-        pinMode(PinDrueckerUW1, INPUT);     // set pin to input
-        pinMode(PinDrueckerUW2, INPUT);     // set pin to input
+        pinMode(PinDrueckerSpielleiter, INPUT);
+        pinMode(PinDrueckerUW1, INPUT);
+        pinMode(PinDrueckerUW2, INPUT);
 
         DrueckerSpielleiter.attach(PinDrueckerSpielleiter);
         DrueckerSpielleiter.interval(10);
@@ -143,20 +132,14 @@ void setup()
         pinMode(PinHorn, OUTPUT);   // Hupe
         digitalWrite(PinHorn, HIGH);
 
-        #endif
-        #if OUTPUT_SERIAL
-        Serial.begin(9600);
-        while (!Serial) {
-          ; // wait for serial port to connect. Needed for native USB port only
-        }
-        #endif
-
-
-
         pinMode(PinButtonReset, INPUT_PULLUP); //Knopf1
         pinMode(PinButtonSetup, INPUT_PULLUP); //Knopf2
         pinMode(PinButtonPlus, INPUT_PULLUP); //Knopf3
         pinMode(PinButtonMinus, INPUT_PULLUP); //Knopf4
+
+        #if OUTPUT_SERIAL
+        Serial.write("setup() finished\n");
+        #endif
 }
 
 
@@ -176,10 +159,10 @@ void loop()
         AutomatischHupen(); // falls automatisch gehupt werden muss wird das gemacht
 
 
-// Drücker Abfragen
-DrueckerSpielleiter.update();
-DrueckerUW1.update();
-DrueckerUW2.update();
+        // Drücker Abfragen
+        DrueckerSpielleiter.update();
+        DrueckerUW1.update();
+        DrueckerUW2.update();
 
 
         if (TimerSpielzeit <= 0)                         // Spiel zu ende - Abhupen, evtl. Halbzeit und reset
@@ -223,7 +206,9 @@ DrueckerUW2.update();
         else if (DrueckerUW1.read() == 0 && HupStatus[0] < 2 && HupStatus[2] < 2)
         {
           digitalWrite(PinHorn, LOW);
+          #if OUTPUT_LED
           lc.setChar(0, 2,'b', false);
+          #endif
         }
         else if (DrueckerUW2.read() == 0 && HupStatus[1] < 2 && HupStatus[0] < 2)
         {

--- a/Code/src/display.h
+++ b/Code/src/display.h
@@ -117,9 +117,6 @@ void zeigSetup()
   lcd.setCursor(0, 1);
   lcd.print("Setu p   ");
   #endif
-  #if OUTPUT_SERIAL
-  Serial.write("Setup");
-  #endif
 }
 
 void zeigSetupIndikator(char c)


### PR DESCRIPTION
Wenn BT aus war wurden die Drücker und die Hupe nicht mehr initialisiert.

Wenn LED aus war, gab's einen Compiler Fehler.

Außerdem hab ich die platformio.ini etwas aufgeräumt. Irgendwie funktioniert das lib_deps aber nur so halb. Wenn ich LiquidCrystal (887) dazu hab, dann hat's nimmer gebaut.